### PR TITLE
Add new functions to parse scalar expressions

### DIFF
--- a/caqtus/shot_compilation/_evaluation/__init__.py
+++ b/caqtus/shot_compilation/_evaluation/__init__.py
@@ -1,0 +1,3 @@
+from ._evaluate_scalar_expression import evaluate_scalar_expression
+
+__all__ = ["evaluate_scalar_expression"]

--- a/caqtus/shot_compilation/_evaluation/__init__.py
+++ b/caqtus/shot_compilation/_evaluation/__init__.py
@@ -1,3 +1,4 @@
 from ._evaluate_scalar_expression import evaluate_scalar_expression
+from ._exceptions import UndefinedParameterError
 
-__all__ = ["evaluate_scalar_expression"]
+__all__ = ["evaluate_scalar_expression", "UndefinedParameterError"]

--- a/caqtus/shot_compilation/_evaluation/_constants.py
+++ b/caqtus/shot_compilation/_evaluation/_constants.py
@@ -1,0 +1,9 @@
+from collections.abc import Mapping
+
+
+CONSTANTS: Mapping = {
+    "pi": 3.141592653589793,
+    "e": 2.718281828459045,
+    "Enabled": True,
+    "Disabled": False,
+}

--- a/caqtus/shot_compilation/_evaluation/_constants.py
+++ b/caqtus/shot_compilation/_evaluation/_constants.py
@@ -1,8 +1,10 @@
 from collections.abc import Mapping
 
+from caqtus.types.units import Quantity, Unit
+from ._scalar import Scalar
 
-CONSTANTS: Mapping = {
-    "pi": 3.141592653589793,
+CONSTANTS: Mapping[str, Scalar] = {
+    "pi": Quantity(3.141592653589793, Unit("rad")),
     "e": 2.718281828459045,
     "Enabled": True,
     "Disabled": False,

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -10,7 +10,7 @@ from caqtus.types.units import Quantity, is_scalar_quantity
 from caqtus.types.variable_name import DottedVariableName
 from caqtus_parsing import parse
 from ._constants import CONSTANTS
-from ._exceptions import UndefinedParameterError
+from ._exceptions import UndefinedParameterError, InvalidOperationError
 
 type Scalar = int | bool | float | Quantity[float]
 
@@ -44,7 +44,8 @@ def evaluate_expression(
             nodes.Add()
             | nodes.Subtract()
             | nodes.Multiply()
-            | nodes.Divide() as binary_operator
+            | nodes.Divide()
+            | nodes.Power() as binary_operator
         ):
             return evaluate_binary_operator(binary_operator, parameters)
         case _:  # pragma: no cover
@@ -80,6 +81,12 @@ def evaluate_binary_operator(
             result = left * right
         case nodes.Divide():
             result = left / right
+        case nodes.Power(exponent):
+            if not isinstance(right, (int, float)):
+                raise InvalidOperationError(
+                    f"The exponent {exponent} must be a real number."
+                )
+            result = left**right
         case _:  # pragma: no cover
             assert_never(binary_operator)
     if not is_scalar(result):

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -48,6 +48,8 @@ def evaluate_expression(
             | nodes.Power() as binary_operator
         ):
             return evaluate_binary_operator(binary_operator, parameters)
+        case nodes.Plus() | nodes.Minus() as unary_operator:
+            return evaluate_unary_operator(unary_operator, parameters)
         case _:  # pragma: no cover
             assert_never(expression)
 
@@ -92,6 +94,25 @@ def evaluate_binary_operator(
     if not is_scalar(result):
         raise AssertionError(
             "A binary operation between scalars should return a scalar."
+        )
+    return result
+
+
+def evaluate_unary_operator(
+    unary_operator: nodes.UnaryOperator,
+    parameters: Mapping[DottedVariableName, Parameter],
+) -> Scalar:
+    operand = evaluate_expression(unary_operator.operand, parameters)
+    match unary_operator:
+        case nodes.Plus():
+            result = operand
+        case nodes.Minus():
+            result = -operand
+        case _:  # pragma: no cover
+            assert_never(unary_operator)
+    if not is_scalar(result):
+        raise AssertionError(
+            "A unary operation between scalars should return a scalar."
         )
     return result
 

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -1,0 +1,36 @@
+from collections.abc import Mapping
+from typing import assert_never
+
+import caqtus_parsing.nodes as nodes
+from caqtus.types.expression import Expression
+from caqtus.types.parameter import Parameter
+from caqtus.types.units import Quantity
+from caqtus.types.variable_name import DottedVariableName
+from caqtus_parsing import parse
+
+type Scalar = int | bool | float | Quantity[float]
+
+
+def evaluate_scalar_expression(
+    expression: Expression, parameters: Mapping[DottedVariableName, Parameter]
+) -> Scalar:
+    """Evaluate a scalar expression.
+
+    Args:
+        expression: The expression to evaluate.
+        parameters: The parameters to use in the evaluation.
+
+    Returns:
+        The result of the evaluation.
+    """
+
+    ast = parse(str(expression))
+    return evaluate_expression(ast)
+
+
+def evaluate_expression(expression: nodes.Expression) -> Scalar:
+    match expression:
+        case int() | float():
+            return expression
+        case _:
+            assert_never(expression)

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -101,7 +101,9 @@ def evaluate_function_call(
         # same hash.
         function = SCALAR_FUNCTIONS[function_name]  # type: ignore[reportArgumentType]
     except KeyError:
-        raise UndefinedFunctionError(f"Function {function_name} is not defined.")
+        raise UndefinedFunctionError(
+            f"Function {function_name} is not defined."
+        ) from None
     arguments = [
         evaluate_expression(argument, parameters) for argument in function_call.args
     ]
@@ -179,7 +181,7 @@ def evaluate_units(unit_nodes: Sequence[nodes.UnitTerm]) -> Unit:
         try:
             base = units[unit_term.unit]
         except KeyError:
-            raise UndefinedUnitError(f"Unit {unit_term.unit} is not defined.")
+            raise UndefinedUnitError(f"Unit {unit_term.unit} is not defined.") from None
         exponent = unit_term.exponent or 1
         accumulated_units.append(base**exponent)
     return functools.reduce(operator.mul, accumulated_units)

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -32,5 +32,5 @@ def evaluate_expression(expression: nodes.Expression) -> Scalar:
     match expression:
         case int() | float():
             return expression
-        case _:
+        case _:  # pragma: no cover
             assert_never(expression)

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -1,10 +1,12 @@
 from collections.abc import Mapping
-from typing import assert_never
+from typing import assert_never, Any
+
+from typing_extensions import TypeIs
 
 import caqtus_parsing.nodes as nodes
 from caqtus.types.expression import Expression
 from caqtus.types.parameter import Parameter
-from caqtus.types.units import Quantity
+from caqtus.types.units import Quantity, is_scalar_quantity
 from caqtus.types.variable_name import DottedVariableName
 from caqtus_parsing import parse
 from ._constants import CONSTANTS
@@ -38,6 +40,13 @@ def evaluate_expression(
             return expression
         case nodes.Variable() as variable:
             return evaluate_scalar_variable(variable, parameters)
+        case (
+            nodes.Add()
+            | nodes.Subtract()
+            | nodes.Multiply()
+            | nodes.Divide() as binary_operator
+        ):
+            return evaluate_binary_operator(binary_operator, parameters)
         case _:  # pragma: no cover
             assert_never(expression)
 
@@ -54,3 +63,29 @@ def evaluate_scalar_variable(
         return CONSTANTS[name]
     else:
         raise UndefinedParameterError(f"Parameter {name} is not defined.")
+
+
+def evaluate_binary_operator(
+    binary_operator: nodes.BinaryOperator,
+    parameters: Mapping[DottedVariableName, Parameter],
+) -> Scalar:
+    left = evaluate_expression(binary_operator.left, parameters)
+    right = evaluate_expression(binary_operator.right, parameters)
+    match binary_operator:
+        case nodes.Add():
+            result = left + right
+        case nodes.Subtract():
+            result = left - right
+        case nodes.Multiply():
+            result = left * right
+        case nodes.Divide():
+            result = left / right
+        case _:  # pragma: no cover
+            assert_never(binary_operator)
+    if not is_scalar(result):
+        raise AssertionError("Adding two scalars should result in a scalar.")
+    return result
+
+
+def is_scalar(value: Any) -> TypeIs[Scalar]:
+    return isinstance(value, (int, bool, float)) or is_scalar_quantity(value)

--- a/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
+++ b/caqtus/shot_compilation/_evaluation/_evaluate_scalar_expression.py
@@ -90,7 +90,9 @@ def evaluate_binary_operator(
         case _:  # pragma: no cover
             assert_never(binary_operator)
     if not is_scalar(result):
-        raise AssertionError("Adding two scalars should result in a scalar.")
+        raise AssertionError(
+            "A binary operation between scalars should return a scalar."
+        )
     return result
 
 

--- a/caqtus/shot_compilation/_evaluation/_exceptions.py
+++ b/caqtus/shot_compilation/_evaluation/_exceptions.py
@@ -1,0 +1,9 @@
+from caqtus.types.recoverable_exceptions import InvalidValueError, RecoverableException
+
+
+class EvaluationError(RecoverableException):
+    """An error that occurred while evaluating an expression."""
+
+
+class UndefinedParameterError(InvalidValueError):
+    """Indicates that a parameter was not defined in an expression."""

--- a/caqtus/shot_compilation/_evaluation/_exceptions.py
+++ b/caqtus/shot_compilation/_evaluation/_exceptions.py
@@ -1,8 +1,4 @@
-from caqtus.types.recoverable_exceptions import InvalidValueError, RecoverableException
-
-
-class EvaluationError(RecoverableException):
-    """An error that occurred while evaluating an expression."""
+from caqtus.types.recoverable_exceptions import EvaluationError
 
 
 class UndefinedParameterError(EvaluationError):

--- a/caqtus/shot_compilation/_evaluation/_exceptions.py
+++ b/caqtus/shot_compilation/_evaluation/_exceptions.py
@@ -7,3 +7,7 @@ class UndefinedParameterError(EvaluationError):
 
 class InvalidOperationError(EvaluationError):
     """Indicates that an invalid operation was attempted."""
+
+
+class UndefinedUnitError(EvaluationError):
+    """Indicates that a unit was not defined in an expression."""

--- a/caqtus/shot_compilation/_evaluation/_exceptions.py
+++ b/caqtus/shot_compilation/_evaluation/_exceptions.py
@@ -5,5 +5,9 @@ class EvaluationError(RecoverableException):
     """An error that occurred while evaluating an expression."""
 
 
-class UndefinedParameterError(InvalidValueError):
+class UndefinedParameterError(EvaluationError):
     """Indicates that a parameter was not defined in an expression."""
+
+
+class InvalidOperationError(EvaluationError):
+    """Indicates that an invalid operation was attempted."""

--- a/caqtus/shot_compilation/_evaluation/_functions.py
+++ b/caqtus/shot_compilation/_evaluation/_functions.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Callable
+from typing import SupportsFloat, Protocol
+
+import numpy
+
+from caqtus.types.recoverable_exceptions import InvalidTypeError
+from caqtus.types.units import DimensionalityError
+from caqtus.types.variable_name import VariableName
+from ._scalar import Scalar
+
+SCALAR_FUNCTIONS: Mapping[VariableName, ScalarFunction]
+
+
+class InvalidArgumentCountError(InvalidTypeError):
+    pass
+
+
+class ScalarFunction(Protocol):
+    """A function that operates on scalars."""
+
+    def __call__(self, *args: Scalar) -> Scalar:
+        """Call the function with the given arguments.
+
+        The function must accept a variable number of arguments, even if the underlying
+        function is only defined for a specific number of arguments.
+        This is because the user can mess up and enter the wrong number of arguments,
+        but the function must still handle the error gracefully and raise the correct
+        exception.
+
+        Raises:
+            InvalidArgumentCountError: if the number of arguments passed to the function
+                is not correct.
+            RecoverableError: if the function cannot be evaluated due to the user's
+                input.
+        """
+
+        ...
+
+
+def float_to_scalar_function(
+    function: Callable[[float], SupportsFloat]
+) -> ScalarFunction:
+    """Convert a function operating on a float to a function operating on scalars."""
+
+    def wrapper(*args: Scalar):
+        if len(args) != 1:
+            raise InvalidArgumentCountError(
+                f"{function.__name__}() can only be called with one argument, got "
+                f"{len(args)}."
+            )
+        value = args[0]
+        try:
+            converted = float(value)
+        except (ValueError, DimensionalityError):
+            raise InvalidTypeError(
+                f"{function.__name__}() expected a number, got {value!r}."
+            )
+        return float(function(converted))
+
+    return wrapper
+
+
+SCALAR_FUNCTIONS = {
+    VariableName("abs"): float_to_scalar_function(abs),
+    VariableName("arccos"): float_to_scalar_function(numpy.arccos),
+    VariableName("arcsin"): float_to_scalar_function(numpy.arcsin),
+    VariableName("arctan"): float_to_scalar_function(numpy.arctan),
+    VariableName("cos"): float_to_scalar_function(numpy.cos),
+    VariableName("sin"): float_to_scalar_function(numpy.sin),
+    VariableName("tan"): float_to_scalar_function(numpy.tan),
+    VariableName("exp"): float_to_scalar_function(numpy.exp),
+    VariableName("log"): float_to_scalar_function(numpy.log),
+    VariableName("sqrt"): float_to_scalar_function(numpy.sqrt),
+}

--- a/caqtus/shot_compilation/_evaluation/_functions.py
+++ b/caqtus/shot_compilation/_evaluation/_functions.py
@@ -56,7 +56,7 @@ def float_to_scalar_function(
         except (ValueError, DimensionalityError):
             raise InvalidTypeError(
                 f"{function.__name__}() expected a number, got {value!r}."
-            )
+            ) from None
         return float(function(converted))
 
     return wrapper

--- a/caqtus/shot_compilation/_evaluation/_scalar.py
+++ b/caqtus/shot_compilation/_evaluation/_scalar.py
@@ -1,0 +1,3 @@
+from caqtus.types.units import Quantity
+
+type Scalar = int | bool | float | Quantity[float]

--- a/caqtus/shot_compilation/_evaluation/_units.py
+++ b/caqtus/shot_compilation/_evaluation/_units.py
@@ -1,0 +1,5 @@
+from collections.abc import Mapping
+
+from caqtus.types.units import Unit, unit_registry, UNITS
+
+units: Mapping[str, Unit] = {unit: getattr(unit_registry, unit) for unit in UNITS}

--- a/caqtus/types/units/_units.py
+++ b/caqtus/types/units/_units.py
@@ -156,7 +156,7 @@ POWER_UNITS = {
     "dBm",
 }
 
-DIMENSIONLESS_UNITS = {"dB"}
+DIMENSIONLESS_UNITS = {"dB", "percent", "%"}
 
 CURRENT_UNITS = {"A", "mA"}
 
@@ -164,7 +164,7 @@ VOLTAGE_UNITS = {"V", "mV"}
 
 DISTANCE_UNITS = {"m", "mm", "µm", "um", "nm"}
 
-DEGREE_UNITS = {"deg", "rad"}
+ANGLE_UNITS = {"deg", "°", "rad"}
 
 UNITS = (
     TIME_UNITS
@@ -174,7 +174,7 @@ UNITS = (
     | CURRENT_UNITS
     | VOLTAGE_UNITS
     | DISTANCE_UNITS
-    | DEGREE_UNITS
+    | ANGLE_UNITS
 )
 
 

--- a/caqtus/types/units/_units.py
+++ b/caqtus/types/units/_units.py
@@ -143,6 +143,7 @@ dimensionless = Dimensionless(BaseUnit(Unit("dimensionless")))
 TIME_UNITS = {"s", "ms", "µs", "us", "ns"}
 
 FREQUENCY_UNITS = {
+    "mHz",
     "Hz",
     "kHz",
     "MHz",
@@ -153,14 +154,17 @@ FREQUENCY_UNITS = {
 POWER_UNITS = {
     "W",
     "mW",
+    "µW",
+    "uW",
+    "nW",
     "dBm",
 }
 
 DIMENSIONLESS_UNITS = {"dB", "percent", "%"}
 
-CURRENT_UNITS = {"A", "mA"}
+CURRENT_UNITS = {"A", "mA", "µA", "uA", "nA"}
 
-VOLTAGE_UNITS = {"V", "mV"}
+VOLTAGE_UNITS = {"V", "mV", "µV", "uV", "nV"}
 
 DISTANCE_UNITS = {"m", "mm", "µm", "um", "nm"}
 

--- a/caqtus/types/units/unit_namespace.py
+++ b/caqtus/types/units/unit_namespace.py
@@ -1,6 +1,5 @@
 from collections.abc import Mapping
 
 from ._units import UNITS, ureg, Unit
-from ..variable_name import VariableName
 
 units: Mapping[str, Unit] = {unit: getattr(ureg, unit) for unit in UNITS}

--- a/caqtus/types/units/unit_namespace.py
+++ b/caqtus/types/units/unit_namespace.py
@@ -3,6 +3,4 @@ from collections.abc import Mapping
 from ._units import UNITS, ureg, Unit
 from ..variable_name import VariableName
 
-units: Mapping[VariableName, Unit] = {
-    VariableName(unit): getattr(ureg, unit) for unit in UNITS
-}
+units: Mapping[str, Unit] = {unit: getattr(ureg, unit) for unit in UNITS}

--- a/caqtus/types/units/units_definition.txt
+++ b/caqtus/types/units/units_definition.txt
@@ -198,7 +198,7 @@ thomson_cross_section = 8 / 3 * π * r_e ** 2 = σ_e = sigma_e
 
 # Angle
 turn = 2 * π * radian = _ = revolution = cycle = circle
-degree = π / 180 * radian = deg = arcdeg = arcdegree = angular_degree
+degree = π / 180 * radian = deg = arcdeg = arcdegree = angular_degree = °
 arcminute = degree / 60 = arcmin = arc_minute = angular_minute
 arcsecond = arcminute / 60 = arcsec = arc_second = angular_second
 milliarcsecond = 1e-3 * arcsecond = mas

--- a/caqtus/types/variable_name.py
+++ b/caqtus/types/variable_name.py
@@ -8,7 +8,7 @@ import attrs
 from caqtus.utils import serialization
 
 
-@attrs.define
+@attrs.define(repr=False, eq=False, init=False)
 class DottedVariableName:
     """Represents the name of a parameter.
 
@@ -72,7 +72,7 @@ def dotted_variable_name_converter(name: Any) -> DottedVariableName:
         raise InvalidVariableNameError(f"Invalid variable name: {name}")
 
 
-@attrs.define
+@attrs.define(eq=False, repr=False, init=False)
 class VariableName(DottedVariableName):
     """Represents a single variable name."""
 
@@ -94,6 +94,8 @@ class VariableName(DottedVariableName):
     def __eq__(self, other):
         if isinstance(other, VariableName):
             return self._dotted_name == other._dotted_name
+        elif isinstance(other, str):
+            return self._dotted_name == other
         else:
             return NotImplemented
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "setuptools",
     "docstring_parser",
     "docstring-inheritance>=2.2.1",
-    "caqtus-parsing>=0.2.0",
+    "caqtus-parsing>=0.3.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "setuptools",
     "docstring_parser",
     "docstring-inheritance>=2.2.1",
+    "caqtus-parsing>=0.2.0",
 ]
 
 [project.urls]

--- a/tests/test_shot_compilation/test_evaluation/test_binary_op.py
+++ b/tests/test_shot_compilation/test_evaluation/test_binary_op.py
@@ -1,5 +1,8 @@
+import pytest
+
 from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
 from caqtus.types.expression import Expression
+from caqtus.types.recoverable_exceptions import EvaluationError
 from caqtus.types.variable_name import DottedVariableName
 
 
@@ -41,3 +44,10 @@ def test_power():
 
     result = evaluate_scalar_expression(expr, parameters)
     assert result == 8
+
+
+def test_power_quantity():
+    expr = Expression("1**5 MHz")
+
+    with pytest.raises(EvaluationError):
+        evaluate_scalar_expression(expr, {})

--- a/tests/test_shot_compilation/test_evaluation/test_binary_op.py
+++ b/tests/test_shot_compilation/test_evaluation/test_binary_op.py
@@ -33,3 +33,11 @@ def test_divide():
 
     result = evaluate_scalar_expression(expr, parameters)
     assert result == 12 / 13
+
+
+def test_power():
+    expr = Expression("a ** b")
+    parameters = {DottedVariableName("a"): 2, DottedVariableName("b"): 3}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == 8

--- a/tests/test_shot_compilation/test_evaluation/test_binary_op.py
+++ b/tests/test_shot_compilation/test_evaluation/test_binary_op.py
@@ -1,0 +1,35 @@
+from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
+from caqtus.types.expression import Expression
+from caqtus.types.variable_name import DottedVariableName
+
+
+def test_add():
+    expr = Expression("a + b")
+    parameters = {DottedVariableName("a"): 12, DottedVariableName("b"): 13}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == 25
+
+
+def test_subtract():
+    expr = Expression("a - b")
+    parameters = {DottedVariableName("a"): 12, DottedVariableName("b"): 13}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == -1
+
+
+def test_multiply():
+    expr = Expression("a * b")
+    parameters = {DottedVariableName("a"): 12, DottedVariableName("b"): 13}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == 156
+
+
+def test_divide():
+    expr = Expression("a / b")
+    parameters = {DottedVariableName("a"): 12, DottedVariableName("b"): 13}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == 12 / 13

--- a/tests/test_shot_compilation/test_evaluation/test_call.py
+++ b/tests/test_shot_compilation/test_evaluation/test_call.py
@@ -1,0 +1,18 @@
+import math
+
+from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
+from caqtus.types.expression import Expression
+
+
+def test_call():
+    expr = Expression("sqrt(2)")
+
+    result = evaluate_scalar_expression(expr, {})
+    assert result == 2**0.5
+
+
+def test_with_quantity():
+    expr = Expression("cos(0 dB)")
+
+    result = evaluate_scalar_expression(expr, {})
+    assert result == math.cos(1)

--- a/tests/test_shot_compilation/test_evaluation/test_call.py
+++ b/tests/test_shot_compilation/test_evaluation/test_call.py
@@ -1,7 +1,9 @@
-import math
+import pytest
 
 from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
 from caqtus.types.expression import Expression
+from caqtus.types.units import Quantity, Unit
+from caqtus.types.variable_name import DottedVariableName
 
 
 def test_call():
@@ -12,7 +14,19 @@ def test_call():
 
 
 def test_with_quantity():
-    expr = Expression("cos(0 dB)")
+    expr = Expression("cos(90°)")
 
     result = evaluate_scalar_expression(expr, {})
-    assert result == math.cos(1)
+    assert result == pytest.approx(0)
+
+
+def test_rad():
+    expr = Expression("cos(2 * pi * t * freq)")
+
+    parameters = {
+        DottedVariableName("t"): Quantity(0.5, Unit("s")),
+        DottedVariableName("freq"): Quantity(2, Unit("Hz")),
+    }
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == pytest.approx(1)

--- a/tests/test_shot_compilation/test_evaluation/test_int.py
+++ b/tests/test_shot_compilation/test_evaluation/test_int.py
@@ -1,0 +1,9 @@
+from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
+from caqtus.types.expression import Expression
+
+
+def test_evaluate_integer():
+    expr = Expression("12")
+
+    result = evaluate_scalar_expression(expr, {})
+    assert result == 12

--- a/tests/test_shot_compilation/test_evaluation/test_int.py
+++ b/tests/test_shot_compilation/test_evaluation/test_int.py
@@ -6,4 +6,13 @@ def test_evaluate_integer():
     expr = Expression("12")
 
     result = evaluate_scalar_expression(expr, {})
+    assert isinstance(result, int)
     assert result == 12
+
+
+def test_evaluate_float():
+    expr = Expression("-12.5")
+
+    result = evaluate_scalar_expression(expr, {})
+    assert isinstance(result, float)
+    assert result == -12.5

--- a/tests/test_shot_compilation/test_evaluation/test_unary_operators.py
+++ b/tests/test_shot_compilation/test_evaluation/test_unary_operators.py
@@ -1,0 +1,19 @@
+from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
+from caqtus.types.expression import Expression
+from caqtus.types.variable_name import DottedVariableName
+
+
+def test_plus_operator():
+    expr = Expression("+a")
+    parameters = {DottedVariableName("a"): 12}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == 12
+
+
+def test_minus_operator():
+    expr = Expression("-mot.detuning")
+    parameters = {DottedVariableName("mot.detuning"): 12}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == -12

--- a/tests/test_shot_compilation/test_evaluation/test_units.py
+++ b/tests/test_shot_compilation/test_evaluation/test_units.py
@@ -1,0 +1,30 @@
+import pytest
+
+from caqtus.shot_compilation._evaluation import evaluate_scalar_expression
+from caqtus.types.expression import Expression
+from caqtus.types.recoverable_exceptions import EvaluationError
+from caqtus.types.units import Unit, Quantity
+
+
+def test_units():
+    expr = Expression("12 MHz")
+    parameters = {}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == Quantity(12, Unit("MHz"))
+
+
+def test_undefined_units():
+    expr = Expression("12 foo")
+    parameters = {}
+
+    with pytest.raises(EvaluationError):
+        evaluate_scalar_expression(expr, parameters)
+
+
+def test_fractional_units():
+    expr = Expression("12.5 MHz / V")
+    parameters = {}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == Quantity(12.5, Unit("MHz/V"))

--- a/tests/test_shot_compilation/test_evaluation/test_units.py
+++ b/tests/test_shot_compilation/test_evaluation/test_units.py
@@ -28,3 +28,18 @@ def test_fractional_units():
 
     result = evaluate_scalar_expression(expr, parameters)
     assert result == Quantity(12.5, Unit("MHz/V"))
+
+
+def test_degree():
+    expr = Expression("180°")
+    parameters = {}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == Quantity(180, Unit("°"))
+
+
+def test_percent():
+    expr = Expression("50%")
+
+    result = evaluate_scalar_expression(expr, {})
+    assert result == 0.5

--- a/tests/test_shot_compilation/test_evaluation/test_variable.py
+++ b/tests/test_shot_compilation/test_evaluation/test_variable.py
@@ -1,0 +1,43 @@
+import pytest
+
+from caqtus.shot_compilation._evaluation import (
+    evaluate_scalar_expression,
+    UndefinedParameterError,
+)
+from caqtus.shot_compilation._evaluation._constants import CONSTANTS
+from caqtus.types.expression import Expression
+from caqtus.types.variable_name import DottedVariableName
+
+
+def test_variable_evaluation():
+    expr = Expression("a")
+    parameters = {DottedVariableName("a"): 12}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert isinstance(result, int)
+    assert result == 12
+
+
+def test_dotted_parameter():
+    expr = Expression("a.b")
+    parameters = {DottedVariableName("a.b"): 12}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert isinstance(result, int)
+    assert result == 12
+
+
+def test_undefined_parameter():
+    expr = Expression("a")
+    parameters = {}
+
+    with pytest.raises(UndefinedParameterError):
+        evaluate_scalar_expression(expr, parameters)
+
+
+def test_constant():
+    expr = Expression("pi")
+    parameters = {}
+
+    result = evaluate_scalar_expression(expr, parameters)
+    assert result == CONSTANTS["pi"]

--- a/tests/test_shot_compilation/test_evaluation/test_variable.py
+++ b/tests/test_shot_compilation/test_evaluation/test_variable.py
@@ -2,10 +2,10 @@ import pytest
 
 from caqtus.shot_compilation._evaluation import (
     evaluate_scalar_expression,
-    UndefinedParameterError,
 )
 from caqtus.shot_compilation._evaluation._constants import CONSTANTS
 from caqtus.types.expression import Expression
+from caqtus.types.recoverable_exceptions import EvaluationError
 from caqtus.types.variable_name import DottedVariableName
 
 
@@ -31,7 +31,7 @@ def test_undefined_parameter():
     expr = Expression("a")
     parameters = {}
 
-    with pytest.raises(UndefinedParameterError):
+    with pytest.raises(EvaluationError):
         evaluate_scalar_expression(expr, parameters)
 
 


### PR DESCRIPTION
The PR adds the possibility to parse user entered expressions into an AST and then to evaluate these expressions to simple scalar values.

At term, this should replace the use of `eval` for evaluating expressions and give more flexibility.